### PR TITLE
feat: automatically grant read of credentials secret

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,6 @@ import { TailscaleBastion } from 'cdk-tailscale-bastion';
 // Secrets Manager
 const secret = Secret.fromSecretNameV2(stack, 'ApiSecrets', 'tailscale').secretValueFromJson('AUTH_KEY');
 
-
 const bastion = new TailscaleBastion(stack, 'Sample-Bastion', {
   vpc,
   tailscaleCredentials: {
@@ -32,8 +31,6 @@ const bastion = new TailscaleBastion(stack, 'Sample-Bastion', {
   },
 });
 
-// Remember to allow the host to read the secret!
-secret.grantRead(bastion.bastion);
 ```
 
 Whatever resource you intend to reach should permit connections from the bastion on the relevant port, naturally. 

--- a/src/index.ts
+++ b/src/index.ts
@@ -104,6 +104,10 @@ export class TailscaleBastion extends Construct {
       ),
     });
 
+    if (props.tailscaleCredentials.secretsManager) {
+      props.tailscaleCredentials.secretsManager.secret.grantRead(bastion);
+    }
+
     bastion.connections.allowFromAnyIpv4(Port.udp(41641));
     bastion.connections.allowFrom(Peer.anyIpv6(), Port.udp(41641));
 

--- a/src/integ.default.ts
+++ b/src/integ.default.ts
@@ -14,7 +14,7 @@ const secret = Secret.fromSecretNameV2(stack, 'ApiSecrets', 'tailscale');
 // Systems Manager Parameter Store
 //const altSecret = SecretValue.ssmSecure('/tsauth');
 
-const bastion = new TailscaleBastion(stack, 'Cdk-Sample-Lib', {
+new TailscaleBastion(stack, 'Cdk-Sample-Lib', {
   vpc,
   tailscaleCredentials: {
     secretsManager: {
@@ -23,5 +23,3 @@ const bastion = new TailscaleBastion(stack, 'Cdk-Sample-Lib', {
     },
   },
 });
-
-secret.grantRead(bastion.bastion);

--- a/test/construct.test.ts
+++ b/test/construct.test.ts
@@ -12,7 +12,7 @@ const vpc = new Vpc(stack, 'MyVpc');
 
 const secret = Secret.fromSecretNameV2(stack, 'ApiSecrets', 'tailscale');
 
-const bastion = new TailscaleBastion(stack, 'Test-Bastion', {
+new TailscaleBastion(stack, 'Test-Bastion', {
   vpc: vpc,
   tailscaleCredentials: {
     secretsManager: {
@@ -21,8 +21,6 @@ const bastion = new TailscaleBastion(stack, 'Test-Bastion', {
     },
   },
 });
-
-secret.grantRead(bastion.bastion);
 
 const template = Template.fromStack(stack);
 


### PR DESCRIPTION
If the user provides a SecretsManager secret, the construct will automatically grant reading this secret to the instance's role