### PR TITLE
feat: support incoming routes from Tailscale

### DIFF
--- a/API.md
+++ b/API.md
@@ -191,6 +191,7 @@ const tailscaleBastionProps: TailscaleBastionProps = { ... }
 | <code><a href="#cdk-tailscale-bastion.TailscaleBastionProps.property.vpc">vpc</a></code> | <code>aws-cdk-lib.aws_ec2.Vpc</code> | VPC to launch the instance in. |
 | <code><a href="#cdk-tailscale-bastion.TailscaleBastionProps.property.additionalInit">additionalInit</a></code> | <code>aws-cdk-lib.aws_ec2.InitElement[]</code> | Additional cloudformation init actions to perform during startup. |
 | <code><a href="#cdk-tailscale-bastion.TailscaleBastionProps.property.availabilityZone">availabilityZone</a></code> | <code>string</code> | In which AZ to place the instance within the VPC. |
+| <code><a href="#cdk-tailscale-bastion.TailscaleBastionProps.property.incomingRoutes">incomingRoutes</a></code> | <code>string[]</code> | List of incoming routes from Tailscale network. |
 | <code><a href="#cdk-tailscale-bastion.TailscaleBastionProps.property.instanceName">instanceName</a></code> | <code>string</code> | The name of the instance. |
 | <code><a href="#cdk-tailscale-bastion.TailscaleBastionProps.property.instanceType">instanceType</a></code> | <code>aws-cdk-lib.aws_ec2.InstanceType</code> | Type of instance to launch. |
 | <code><a href="#cdk-tailscale-bastion.TailscaleBastionProps.property.securityGroup">securityGroup</a></code> | <code>aws-cdk-lib.aws_ec2.ISecurityGroup</code> | Security Group to assign to this instance. |
@@ -247,6 +248,21 @@ public readonly availabilityZone: string;
 - *Default:* Random zone.
 
 In which AZ to place the instance within the VPC.
+
+---
+
+##### `incomingRoutes`<sup>Optional</sup> <a name="incomingRoutes" id="cdk-tailscale-bastion.TailscaleBastionProps.property.incomingRoutes"></a>
+
+```typescript
+public readonly incomingRoutes: string[];
+```
+
+- *Type:* string[]
+- *Default:* none
+
+List of incoming routes from Tailscale network.
+
+VPC route table will get these targets added.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -53,3 +53,17 @@ You'll also need to setup the nameserver. The bastion construct conveniently out
 <img src="https://user-images.githubusercontent.com/975824/177154488-3f3c1d02-35c6-432b-96fc-9dca691ea94c.png" height="250px" />
 
 Given your configuration is correct, a direct connection to your internal resources should now be possible.
+
+## Incoming routes
+
+If you have other subnet routers configured in Tailscale, you can use the `incomingRoutes` property to configure VPC route table entries for all private subnets.
+
+```
+new TailscaleBastion(stack, 'Sample-Bastion', {
+  vpc,
+  tailscaleCredentials: ...
+  incomingRoutes: [
+    '192.168.1.0/24',
+  ],
+});
+```

--- a/test/construct.test.ts
+++ b/test/construct.test.ts
@@ -107,7 +107,7 @@ test('Bastion host should be created', () => {
                         'CidrBlock',
                       ],
                     },
-                    ' --accept-dns=false',
+                    ' --accept-routes --accept-dns=false',
                   ],
                 ],
               },

--- a/test/routes.test.ts
+++ b/test/routes.test.ts
@@ -1,0 +1,48 @@
+import { App, Stack } from 'aws-cdk-lib';
+import { Match, Template } from 'aws-cdk-lib/assertions';
+import { Vpc } from 'aws-cdk-lib/aws-ec2';
+import { Secret } from 'aws-cdk-lib/aws-secretsmanager';
+import { TailscaleBastion } from '../src';
+
+const mockApp = new App();
+
+const stack = new Stack(mockApp, 'MyStack');
+
+const vpc = new Vpc(stack, 'MyVpc');
+
+const secret = Secret.fromSecretNameV2(stack, 'ApiSecrets', 'tailscale');
+
+const bastion = new TailscaleBastion(stack, 'Test-Bastion', {
+  vpc: vpc,
+  tailscaleCredentials: {
+    secretsManager: {
+      secret: secret,
+      key: 'AUTH_KEY',
+    },
+  },
+  incomingRoutes: [
+    '192.168.1.0/24',
+  ],
+});
+
+secret.grantRead(bastion.bastion);
+
+const template = Template.fromStack(stack);
+
+test('Bastion host should have routing set up', () => {
+  template.resourceCountIs('AWS::EC2::Instance', 1);
+  template.resourceCountIs('AWS::EC2::Route', 6);
+
+  template.hasResourceProperties('AWS::EC2::Route', {
+    RouteTableId: {
+      Ref: Match.stringLikeRegexp('MyVpcPrivateSubnet1RouteTable'),
+    },
+    DestinationCidrBlock: '192.168.1.0/24',
+    InstanceId: {
+      Ref: Match.stringLikeRegexp('BastionHost'),
+    },
+  })
+
+});
+
+

--- a/test/routes.test.ts
+++ b/test/routes.test.ts
@@ -41,7 +41,7 @@ test('Bastion host should have routing set up', () => {
     InstanceId: {
       Ref: Match.stringLikeRegexp('BastionHost'),
     },
-  })
+  });
 
 });
 


### PR DESCRIPTION
Support inbound routes from Tailscale network.

This will create routes in the private subnets to private networks coming from Tailscale