### PR TITLE
feat: replace bastion instance on changes

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -102,6 +102,7 @@ export class TailscaleBastion extends Construct {
         InitCommand.shellCommand(`source /etc/environment && tailscale up --authkey $TS_AUTHKEY --advertise-routes=${props.vpc.vpcCidrBlock} --accept-dns=false`),
         ...(additionalInit ?? []),
       ),
+      initOptions: {},
     });
 
     bastion.connections.allowFromAnyIpv4(Port.udp(41641));


### PR DESCRIPTION
If the userdata or the cfn-init changes, let the bastion host be re-created to roll out these changes.