### PR TITLE
feat: allow cpu type to be passed

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,22 @@
-import { CfnOutput, Fn, Stack, Token } from 'aws-cdk-lib';
-import { BastionHostLinux, CloudFormationInit, InitCommand, ISecurityGroup, Peer, Port, SubnetSelection, IVpc, InstanceType, SubnetType, InitElement, CfnRoute, MachineImage } from 'aws-cdk-lib/aws-ec2';
-import { ISecret } from 'aws-cdk-lib/aws-secretsmanager';
-import { Construct } from 'constructs';
+import {CfnOutput, Fn, Stack, Token} from 'aws-cdk-lib';
+import {
+  AmazonLinuxCpuType,
+  BastionHostLinux,
+  CfnRoute,
+  CloudFormationInit,
+  InitCommand,
+  InitElement,
+  InstanceType,
+  ISecurityGroup,
+  IVpc,
+  MachineImage,
+  Peer,
+  Port,
+  SubnetSelection,
+  SubnetType,
+} from 'aws-cdk-lib/aws-ec2';
+import {ISecret} from 'aws-cdk-lib/aws-secretsmanager';
+import {Construct} from 'constructs';
 
 export interface SecretsManagerAuthKey {
   /**
@@ -82,6 +97,10 @@ export interface TailscaleBastionProps {
    * Advertise a custom route instead of using the VPC CIDR, used for Tailscale 4via6 support.
    */
   readonly advertiseRoute?: string;
+  /**
+   *  CPU Type. Default: AmazonLinuxCpuType.X86_64
+   */
+  readonly cpuType?: AmazonLinuxCpuType;
 }
 
 export class TailscaleBastion extends Construct {
@@ -100,6 +119,7 @@ export class TailscaleBastion extends Construct {
       additionalInit,
       incomingRoutes,
       advertiseRoute,
+      cpuType,
     } = props;
 
     const authKeyCommand = this.computeTsKeyCli(tailscaleCredentials);
@@ -110,7 +130,7 @@ export class TailscaleBastion extends Construct {
       instanceName: instanceName ?? 'BastionHostTailscale',
       securityGroup,
       instanceType,
-      machineImage: MachineImage.latestAmazonLinux2023(),
+      machineImage: MachineImage.latestAmazonLinux2023({cpuType: cpuType ?? AmazonLinuxCpuType.X86_64}),
       subnetSelection: subnetSelection ?? { subnetType: SubnetType.PUBLIC },
       init: CloudFormationInit.fromElements(
         // Configure IP forwarding


### PR DESCRIPTION
The latestAmazonLinux2023() method defaults to the X86_64 cpuType; this allows users to pass an alternative.